### PR TITLE
Explanation Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ export OPENAI_API_KEY=<your_api_key>
 
 After that restart your shell. You can invoke the completion with ALT+G hotkey.
 
+## Alternate Key Bindings
+
+You can change the key bindings by modifying the lines starting with `bindkey` in the script.'
+
+Make sure it doesn't conflict with your existing key bindings. To check, run `bindkey -L` in your shell.
+
 # Contributing
 
 This script is a crude hack, so any help is appreciated, especially if you can write zsh completion scripts. Feel free to open an issue or a pull request.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ export OPENAI_API_KEY=<your_api_key>
 [ -f ~/.lazyshell.zsh ] && source ~/.lazyshell.zsh
 ```
 
-After that restart your shell. You can invoke the completion with ALT+G hotkey.
+After that restart your shell. You can invoke the completion with ALT+G hotkey and explanation with ALT+E.
+
+Note: if you're on macOS and your terminal prints `©` when you press the hotkey, it means the OS intercepts the key combination first and you need to disable this behavior.
 
 ## Alternate Key Bindings
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ LazyShell is in alpha stage and may contain bugs. Currently only Zsh is supporte
 1. Hit ALT+G to invoke the completion. The current command line content will be used as a base for your query.
 2. You can then write a natural language version of what you want to accomplish.
 3. Hit enter.
+4. The suggested command will be inserted into the command line.
+5. Hit enter to execute it, or continue modifying it.
 
 ### Query examples for completion:
 
@@ -32,6 +34,7 @@ Speed up the video 2x using ffmpeg
 
 1. Write down a command you want to understand.
 2. Hit ALT+E to invoke the explanation module.
+3. Hit any key to modify the command (the explanation will disappear)
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Inspired by https://github.com/TheR1D/shell_gpt
 - [ ] support keyboard interrupts
 - [ ] token streaming
 - [x] companion tool that explains the current command line contents
+- [ ] multiline formatting and syntax highlighting for the explanations
 - [ ] allow query editing while the previous one is in progress
 - [ ] make some kind of preview before replacing the buffer
 - [ ] better json escaping

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ LazyShell is a GPT powered utility for Zsh that helps you write and modify conso
 
 LazyShell is currently in alpha stage and may have bugs. Currently only Zsh is supported.
 
-### Query examples:
+# How to use
+
+## Completion
+
+1. Hit ALT+g to invoke the completion. The current command line content will be used as a base for your query.
+2. You can then write a natural language version of what you want to accomplish.
+3. Hit enter.
+
+### Query examples for completion:
 
 ```
 Unpack download.tar.gz
@@ -17,6 +25,11 @@ Start nginx server in docker
 Speed up the video 2x using ffmpeg
     Remove audio track
 ```
+
+## Explanation
+
+1. Write down a command you want to understand.
+2. Hit ALT+e to invoke the explanation module.
 
 # Installation
 
@@ -47,7 +60,7 @@ Inspired by https://github.com/TheR1D/shell_gpt
 - [ ] support for other shells
 - [ ] support keyboard interrupts
 - [ ] token streaming
-- [ ] companion tool that explains the current command line contents
+- [x] companion tool that explains the current command line contents
 - [ ] allow query editing while the previous one is in progress
 - [ ] make some kind of preview before replacing the buffer
 - [ ] better json escaping

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 LazyShell is a GPT powered utility for Zsh that helps you write and modify console commands using natural language. Perfect for those times when you can't remember the command line arguments for `tar` and `ffmpeg`, or when you just want to save time by having AI do the heavy lifting. The tool uses your current command line content (if any) as a base for your query, so you can issue modification requests for it. Invoke the completion with ALT+G hotkey; you still have to manually press enter to execute the suggested command.
 
+It also can use GPT to explain what the current command does. Invoke the explanation with ALT+E hotkey.
+
 ![Screenshot](https://raw.githubusercontent.com/not-poma/lazyshell/master/screenshot.gif)
 
-LazyShell is currently in alpha stage and may have bugs. Currently only Zsh is supported.
+LazyShell is in alpha stage and may contain bugs. Currently only Zsh is supported.
 
 # How to use
 
 ## Completion
 
-1. Hit ALT+g to invoke the completion. The current command line content will be used as a base for your query.
+1. Hit ALT+G to invoke the completion. The current command line content will be used as a base for your query.
 2. You can then write a natural language version of what you want to accomplish.
 3. Hit enter.
 
@@ -29,11 +31,11 @@ Speed up the video 2x using ffmpeg
 ## Explanation
 
 1. Write down a command you want to understand.
-2. Hit ALT+e to invoke the explanation module.
+2. Hit ALT+E to invoke the explanation module.
 
 # Installation
 
-Get OpenAI API key from [OpenAI dashboard](https://platform.openai.com/account/api-keys).
+Get OpenAI API key from [OpenAI dashboard](https://platform.openai.com/account/api-keys). All new OpenAI accounts get $18 balance for testing.
 
 ```shell
 # install prerequisites

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -88,7 +88,6 @@ lazyshell_complete() {
   local os=$(__get_os_prompt_injection)
 
   local intro="You are a zsh autocomplete script. All your answers are a single command$os, and nothing else. You do not write any human-readable explanations. If you fail to answer, start your reason with \`#\`."
-
   if [[ -z "$buffer_context" ]]; then
     local prompt="$REPLY"
   else
@@ -124,22 +123,9 @@ lazyshell_explain() {
   local buffer_context="$BUFFER"
 
   local os=$(__get_os_prompt_injection)
-
   local intro="You are a zsh script explainer bot$os. You write short and sweet human readable explanations given a zsh script."
   local prompt="This is a zsh command \`$buffer_context\`."
 
-
-  # todo: better escaping
-  local escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g' | sed 's/\n/\\n/g')
-  local data='{"messages":[{"role": "system", "content": "'"$intro"'"},{"role": "user", "content": "'"$escaped_prompt"'"}],"model":"gpt-3.5-turbo","max_tokens":256,"temperature":0}'
-
-  set +m
-  
-  # todo: better escaping
-  local escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g' | sed 's/\n/\\n/g')
-  local data='{"messages":[{"role": "system", "content": "'"$intro"'"},{"role": "user", "content": "'"$escaped_prompt"'"}],"model":"gpt-3.5-turbo","max_tokens":256,"temperature":0}'
-
-  set +m
   local response_file=$(mktemp)
   __llm_api_call
   local response=$(cat "$response_file")

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -143,7 +143,7 @@ lazyshell_explain() {
     return 1
   fi
 
-  zle -R "$generated_text"
+  zle -R "# $generated_text"
   read -k 1
 
   # Replace the current buffer with the generated text

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -11,12 +11,10 @@ __get_distribution_name() {
 __get_os_prompt_injection() {
   local os=$(__get_distribution_name)
   if [[ -n "$os" ]]; then
-    os=" for $os"
+    echo " for $os"
   else
-    os=""
+    echo ""
   fi
-
-  echo $os
 }
 
 __preflight_check() {
@@ -100,7 +98,7 @@ lazyshell_complete() {
 
 
   local os=$(__get_os_prompt_injection)
-  local intro="You are a zsh autocomplete script. All your answers are a single command$os, and nothing else. You do not write any human-readable explanations. If you fail to answer, start your reason with \`#\`."
+  local intro="You are a zsh autocomplete script. All your answers are a single command$os, and nothing else. You do not write any human-readable explanations. If you fail to answer, start your response with \`#\`."
   if [[ -z "$buffer_context" ]]; then
     local prompt="$REPLY"
   else
@@ -128,8 +126,8 @@ lazyshell_explain() {
   local buffer_context="$BUFFER"
 
   local os=$(__get_os_prompt_injection)
-  local intro="You are a zsh script explainer bot$os. You write short and sweet human readable explanations given a zsh script."
-  local prompt="This is a zsh command \`$buffer_context\`."
+  local intro="You are a zsh command explanation assistant$os. You write short explanations what a given zsh command does. You answer with a single paragraph."
+  local prompt="$buffer_context"
   local progress_text="Fetching Explanation..."
 
   __llm_api_call

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -86,7 +86,6 @@ lazyshell_complete() {
   CURSOR=$#BUFFER
 
   local os=$(__get_os_prompt_injection)
-
   local intro="You are a zsh autocomplete script. All your answers are a single command$os, and nothing else. You do not write any human-readable explanations. If you fail to answer, start your reason with \`#\`."
   if [[ -z "$buffer_context" ]]; then
     local prompt="$REPLY"
@@ -145,7 +144,7 @@ lazyshell_explain() {
   fi
 
   # Replace the current buffer with the generated text
-  BUFFER="$buffer_context # $generated_text"
+  BUFFER="$buffer_context"$'\n'"# $generated_text"
   CURSOR=$#BUFFER
 }
 

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -29,9 +29,11 @@ __lzsh_preflight_check() {
 }
 
 __lzsh_llm_api_call() {
-  # calls the llm API, shows a nice spinner while it's running, and returns the answer in $generated_text variable
-  # must be set: $prompt, $intro, $progress_text
-  # called without a subshell be stay in the widget context
+  # calls the llm API, shows a nice spinner while it's running 
+  # called without a subshell to stay in the widget context, returns the answer in $generated_text variable
+  local intro="$1"
+  local prompt="$2"
+  local progress_text="$3"
 
   local response_file=$(mktemp)
 
@@ -104,9 +106,8 @@ __lazyshell_complete() {
   else
     local prompt="Alter zsh command \`$buffer_context\` to comply with query \`$REPLY\`"
   fi
-  local progress_text="Query: $REPLY"
 
-  __lzsh_llm_api_call
+  __lzsh_llm_api_call "$intro" "$prompt" "Query: $REPLY"
 
   # if response starts with '#' it means GPT failed to generate the command
   if [[ "$generated_text" == \#* ]]; then
@@ -128,9 +129,8 @@ __lazyshell_explain() {
   local os=$(__lzsh_get_os_prompt_injection)
   local intro="You are a zsh command explanation assistant$os. You write short and consice explanations what a given zsh command does, including the arguments. You answer with no line breaks."
   local prompt="$buffer_context"
-  local progress_text="Fetching Explanation..."
 
-  __lzsh_llm_api_call
+  __lzsh_llm_api_call "$intro" "$prompt" "Fetching Explanation..."
 
   zle -R "# $generated_text"
   read -k 1

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -120,6 +120,7 @@ lazyshell_explain() {
   $(__preflight_check) || return 1
 
   local buffer_context="$BUFFER"
+  local cursor_position=$CURSOR
 
   local os=$(__get_os_prompt_injection)
   local intro="You are a zsh script explainer bot$os. You write short and sweet human readable explanations given a zsh script."
@@ -148,7 +149,7 @@ lazyshell_explain() {
 
   # Replace the current buffer with the generated text
   BUFFER="$buffer_context"
-  CURSOR=$((${#buffer_context}))
+  CURSOR=$cursor_position
 }
 
 if [ -z "$OPENAI_API_KEY" ]; then

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -145,7 +145,7 @@ lazyshell_explain() {
 
   # Replace the current buffer with the generated text
   BUFFER="$buffer_context"$'\n'"# $generated_text"
-  CURSOR=$#BUFFER
+  CURSOR=$((${#buffer_context}))
 }
 
 if [ -z "$OPENAI_API_KEY" ]; then

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -126,7 +126,7 @@ __lazyshell_explain() {
   local buffer_context="$BUFFER"
 
   local os=$(__lzsh_get_os_prompt_injection)
-  local intro="You are a zsh command explanation assistant$os. You write short explanations what a given zsh command does. You answer with a single paragraph."
+  local intro="You are a zsh command explanation assistant$os. You write short and consice explanations what a given zsh command does, including the arguments. You answer with no line breaks."
   local prompt="$buffer_context"
   local progress_text="Fetching Explanation..."
 

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -8,6 +8,17 @@ __get_distribution_name() {
   fi
 }
 
+__get_os_prompt_injection() {
+  local os=$(__get_distribution_name)
+  if [[ -n "$os" ]]; then
+    os=" for $os"
+  else
+    os=""
+  fi
+
+  echo $os
+}
+
 __preflight_check() {
   if [ -z "$OPENAI_API_KEY" ]; then
     echo ""
@@ -20,50 +31,35 @@ __preflight_check() {
 
 }
 
-lazyshell_complete() {
-  $(__preflight_check) || return 1
-
-  local buffer_context="$BUFFER"
-
-  # Read user input
-  # Todo: use zle to read input
-  local REPLY
-  autoload -Uz read-from-minibuffer
-  read-from-minibuffer '> GPT query: '
-  BUFFER="$buffer_context"
-  CURSOR=$#BUFFER
-
-  local os=$(__get_distribution_name)
-  if [[ -n "$os" ]]; then
-    os=" for $os"
-  else
-    os=""
-  fi
-
-  local intro="You are a zsh autocomplete script. All your answers are a single command$os, and nothing else. You do not write any human-readable explanations. If you fail to answer, start your reason with \`#\`."
-
-  if [[ -z "$buffer_context" ]]; then
-    local prompt="$REPLY"
-  else
-    local prompt="Alter zsh command \`$buffer_context\` to comply with query \`$REPLY\`"
-  fi
+__llm_api_call() {
+  # calls the llm API, writes resp in response_file and shows a nice spinner while it's running
+  # must: $prompt, $intro, $response_file be in the env
+  # optionalL: $REPLY should be in the environment for completion
 
   # todo: better escaping
   local escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g' | sed 's/\n/\\n/g')
   local data='{"messages":[{"role": "system", "content": "'"$intro"'"},{"role": "user", "content": "'"$escaped_prompt"'"}],"model":"gpt-3.5-turbo","max_tokens":256,"temperature":0}'
 
-  # Display a spinner while the API request is running in the background
-  local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
+  # Read the response from file
+  # Todo: avoid using temp files
   set +m
-  local response_file=$(mktemp)
   { curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_API_KEY" -d "$data" https://api.openai.com/v1/chat/completions > "$response_file" } &>/dev/null &
   local pid=$!
+
+  # Display a spinner while the API request is running in the background
+  local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
   while true; do
     for i in "${spinner[@]}"; do
       if ! kill -0 $pid 2> /dev/null; then
         break 2
       fi
-      zle -R "$i GPT query: $REPLY"
+
+      if [[ -n "$REPLY" ]]; then
+        zle -R "$i Building Query: $REPLY"
+      else
+        zle -R "$i Fetching Explanation..."
+      fi
+
       sleep 0.1
     done
   done
@@ -74,9 +70,33 @@ lazyshell_complete() {
     zle -R "Error: API request failed"
     return 1
   fi
+}
 
-  # Read the response from file
-  # Todo: avoid using temp files
+lazyshell_complete() {
+  $(__preflight_check) || return 1
+
+  local buffer_context="$BUFFER"
+
+  # Read user input
+  # Todo: use zle to read input
+  local REPLY
+  autoload -Uz read-from-minibuffer
+  read-from-minibuffer '> Building Query: '
+  BUFFER="$buffer_context"
+  CURSOR=$#BUFFER
+
+  local os=$(__get_os_prompt_injection)
+
+  local intro="You are a zsh autocomplete script. All your answers are a single command$os, and nothing else. You do not write any human-readable explanations. If you fail to answer, start your reason with \`#\`."
+
+  if [[ -z "$buffer_context" ]]; then
+    local prompt="$REPLY"
+  else
+    local prompt="Alter zsh command \`$buffer_context\` to comply with query \`$REPLY\`"
+  fi
+
+  local response_file=$(mktemp)
+  __llm_api_call
   local response=$(cat "$response_file")
   rm "$response_file"
 
@@ -103,54 +123,29 @@ lazyshell_explain() {
 
   local buffer_context="$BUFFER"
 
-  local os=$(__get_distribution_name)
-  if [[ -n "$os" ]]; then
-    os=" for $os"
-  else
-    os=""
-  fi
+  local os=$(__get_os_prompt_injection)
 
-  local intro="You are a zsh script explain bot. You are running on $os. You write short and sweet human readable explanations given a zsh script."
-
+  local intro="You are a zsh script explainer bot$os. You write short and sweet human readable explanations given a zsh script."
   local prompt="This is a zsh command \`$buffer_context\`."
+
 
   # todo: better escaping
   local escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g' | sed 's/\n/\\n/g')
   local data='{"messages":[{"role": "system", "content": "'"$intro"'"},{"role": "user", "content": "'"$escaped_prompt"'"}],"model":"gpt-3.5-turbo","max_tokens":256,"temperature":0}'
 
   set +m
+  
+  # todo: better escaping
+  local escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g' | sed 's/\n/\\n/g')
+  local data='{"messages":[{"role": "system", "content": "'"$intro"'"},{"role": "user", "content": "'"$escaped_prompt"'"}],"model":"gpt-3.5-turbo","max_tokens":256,"temperature":0}'
+
+  set +m
   local response_file=$(mktemp)
-  { curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_API_KEY" -d "$data" https://api.openai.com/v1/chat/completions > "$response_file" } &>/dev/null &
-  local pid=$!
-
-  # TODO: show the spinner
-  # Display a spinner while the API request is running in the background
-  local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
-  local pid=$!
-  while true; do
-    for i in "${spinner[@]}"; do
-      if ! kill -0 $pid 2> /dev/null; then
-        break 2
-      fi
-      zle -R "$i Fetching explanation..."
-      sleep 0.1
-    done
-  done
-
-  wait $pid
-  if [ $? -ne 0 ]; then
-    # todo displayed error is erased immediately, find a better way to display it
-    zle -R "Error: API request failed"
-    return 1
-  fi
-
-  # Read the response from file
-  # Todo: avoid using temp files
+  __llm_api_call
   local response=$(cat "$response_file")
   rm "$response_file"
 
   local generated_text=$(echo -E $response | jq -r '.choices[0].message.content' | xargs | sed -e 's/^`\(.*\)`$/\1/')
-
   local error=$(echo -E $response | jq -r '.error.message')
 
   if [ $? -ne 0 ]; then

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -8,7 +8,7 @@ __get_distribution_name() {
   fi
 }
 
-__lazyshell_complete() {
+__preflight_check() {
   if [ -z "$OPENAI_API_KEY" ]; then
     echo ""
     echo "Error: OPENAI_API_KEY is not set"
@@ -17,6 +17,11 @@ __lazyshell_complete() {
     zle reset-prompt
     return 1
   fi
+
+}
+
+lazyshell_complete() {
+  $(__preflight_check) || return 1
 
   local buffer_context="$BUFFER"
 
@@ -93,6 +98,76 @@ __lazyshell_complete() {
   CURSOR=$#BUFFER
 }
 
+lazyshell_explain() {
+  $(__preflight_check) || return 1
+
+  local buffer_context="$BUFFER"
+
+  local os=$(__get_distribution_name)
+  if [[ -n "$os" ]]; then
+    os=" for $os"
+  else
+    os=""
+  fi
+
+  local intro="You are a zsh script explain bot. You are running on $os. You write short and sweet human readable explanations given a zsh script."
+
+  local prompt="This is a zsh command \`$buffer_context\`. What is this doing?"
+
+  # todo: better escaping
+  local escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g' | sed 's/\n/\\n/g')
+  local data='{"messages":[{"role": "system", "content": "'"$intro"'"},{"role": "user", "content": "'"$escaped_prompt"'"}],"model":"gpt-3.5-turbo","max_tokens":256,"temperature":0}'
+
+  set +m
+  local response_file=$(mktemp)
+  { curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_API_KEY" -d "$data" https://api.openai.com/v1/chat/completions > "$response_file" } &>/dev/null &
+  local pid=$!
+
+  # TODO: show the spinner
+  # Display a spinner while the API request is running in the background
+  local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
+  local pid=$!
+  while true; do
+    for i in "${spinner[@]}"; do
+      if ! kill -0 $pid 2> /dev/null; then
+        break 2
+      fi
+      zle -R "$i Fetching explanation..."
+      sleep 0.1
+    done
+  done
+
+  wait $pid
+  if [ $? -ne 0 ]; then
+    # todo displayed error is erased immediately, find a better way to display it
+    zle -R "Error: API request failed"
+    return 1
+  fi
+
+  # Read the response from file
+  # Todo: avoid using temp files
+  local response=$(cat "$response_file")
+  rm "$response_file"
+
+  local generated_text=$(echo -E $response | jq -r '.choices[0].message.content' | xargs | sed -e 's/^`\(.*\)`$/\1/')
+
+  local error=$(echo -E $response | jq -r '.error.message')
+
+  if [ $? -ne 0 ]; then
+    zle -R "Error: Invalid response from API"
+    return 1
+  fi
+
+  if [[ -n "$error" && "$error" != "null" ]]; then 
+    zle -R "Error: $error"
+    return 1
+  fi
+
+  # Replace the current buffer with the generated text
+  BUFFER="$buffer_context # $generated_text"
+  CURSOR=$#BUFFER
+}
+
 if [ -z "$OPENAI_API_KEY" ]; then
   echo "Warning: OPENAI_API_KEY is not set"
   echo "Get your API key from https://beta.openai.com/account/api-keys and then run:"
@@ -100,5 +175,10 @@ if [ -z "$OPENAI_API_KEY" ]; then
 fi
 
 # Bind the __lazyshell_complete function to the Alt-g hotkey
-zle -N __lazyshell_complete
-bindkey '\eg' __lazyshell_complete
+zle -N lazyshell_complete
+zle -N lazyshell_explain
+bindkey '\eg' lazyshell_complete
+bindkey '\ee' lazyshell_explain
+
+typeset -ga ZSH_AUTOSUGGEST_CLEAR_WIDGETS
+ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=( lazyshell_explain )

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -112,7 +112,7 @@ lazyshell_explain() {
 
   local intro="You are a zsh script explain bot. You are running on $os. You write short and sweet human readable explanations given a zsh script."
 
-  local prompt="This is a zsh command \`$buffer_context\`. What is this doing?"
+  local prompt="This is a zsh command \`$buffer_context\`."
 
   # todo: better escaping
   local escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g' | sed 's/\n/\\n/g')

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -143,8 +143,11 @@ lazyshell_explain() {
     return 1
   fi
 
+  zle -R "$generated_text"
+  read -k 1
+
   # Replace the current buffer with the generated text
-  BUFFER="$buffer_context"$'\n'"# $generated_text"
+  BUFFER="$buffer_context"
   CURSOR=$((${#buffer_context}))
 }
 

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -71,12 +71,12 @@ __lzsh_llm_api_call() {
   generated_text=$(echo -E $response | jq -r '.choices[0].message.content' | xargs -0 | sed -e 's/^`\(.*\)`$/\1/')
 
   if [ $? -ne 0 ]; then
-    zle -M "Error: Invalid response from API"
+    zle -M "Error: Invalid API response format"
     return 1
   fi
 
-  if [[ -n "$error" && "$error" != "null" ]]; then 
-    zle -M "Error: $error"
+  if [[ -n "$error" && "$error" != "null" ]]; then
+    zle -M "API error: $error"
     return 1
   fi
 }


### PR DESCRIPTION
- Use Alt+e to explain what you've written already.
- Adds explanation as `# <explanation>` after the command. 
- Compatible with `zsh-autosuggestions`  

I could refactor it a bit better for less repetitive code, but my preliminary trial fucked up the nice "spinner + replace UX" of `lazyshell_completion` :(