### PR TITLE
Explicit rm invocation to avoid user shell overrides

### DIFF
--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -85,7 +85,8 @@ __lzsh_llm_api_call() {
   fi
 
   local response=$(cat "$response_file")
-  rm "$response_file"
+  # some shell users may have `alias rm="rm -i"` so use \rm for unaliased rm in user shell
+  \rm "$response_file"
 
   local error=$(echo -E $response | jq -r '.error.message')
   generated_text=$(echo -E $response | jq -r '.choices[0].message.content' | tr '\n' '\r' | sed -e $'s/^[ \r`]*//; s/[ \r`]*$//' | tr '\r' '\n')

--- a/lazyshell.zsh
+++ b/lazyshell.zsh
@@ -85,8 +85,8 @@ __lzsh_llm_api_call() {
   fi
 
   local response=$(cat "$response_file")
-  # some shell users may have `alias rm="rm -i"` so use \rm for unaliased rm in user shell
-  \rm "$response_file"
+  # explicit rm invocation to avoid user shell overrides
+  command rm "$response_file"
 
   local error=$(echo -E $response | jq -r '.error.message')
   generated_text=$(echo -E $response | jq -r '.choices[0].message.content' | tr '\n' '\r' | sed -e $'s/^[ \r`]*//; s/[ \r`]*$//' | tr '\r' '\n')


### PR DESCRIPTION
This avoids confirmation prompt to remove the tmp file for users with `alias rm="rm -i"` in their terminal.